### PR TITLE
Escape regExp special characters

### DIFF
--- a/lib/autocomplete/autocomplete-suggestions.js
+++ b/lib/autocomplete/autocomplete-suggestions.js
@@ -79,11 +79,11 @@ module.exports = {
     if (!startWith) {
       return suggestion;
     }
-
-    if (suggestion.match(startWith)) {
+    
+    if (suggestion.match(_.escapeRegExp(startWith))) {
       return suggestion;
     }
-
+    
     return null;
   }
 

--- a/test/autocomplete/autocomplete-suggestions.js
+++ b/test/autocomplete/autocomplete-suggestions.js
@@ -88,6 +88,12 @@ describe('<Unit Test>', function () {
           done();
         });
       });
+   
+      it('should not throw error when current word contains regex special characters', function () {
+        should(function () {
+          autocompleteOption.parseStrings(parser, ["#", "#"], ')(');
+        }).not.throw()
+      });
 
       it('should return that it need to load the action code for the autocomplete action', function () {
         var suggestion = autocompleteOption.parseStrings(parser, ["member did action #eat", "member did action eat#"], 'eat');

--- a/test/autocomplete/autocomplete-suggestions.js
+++ b/test/autocomplete/autocomplete-suggestions.js
@@ -89,9 +89,9 @@ describe('<Unit Test>', function () {
         });
       });
    
-      it('should not throw error when current word contains regex special characters', function () {
+      it.only('should not throw error when current word contains regex special characters', function () {
         should(function () {
-          autocompleteOption.parseStrings(parser, ["#", "#"], ')(');
+          autocompleteOption.parseStrings(parser, ["#", "#"], ' .*+?^$}{)(|][');
         }).not.throw()
       });
 


### PR DESCRIPTION
Now `parseStrings` doesn\'t throw an exception when we use characters like [.*+?^${}()|[\]\\]
